### PR TITLE
Feature: Support self-hosted and local S3 instances

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,13 @@
 AWS_REGION=eu-central-1
 AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-# AWS_ENDPOINT_OVERRIDE=https://my-selfhosted-s3-instance.com
+# AWS endpoint override; e.g. for local development or self-hosted S3.
+AWS_ENDPOINT_OVERRIDE=
 # Name of the S3 bucket.
 BUCKET_NAME=www.example.com
 # Object key regex pattern for exclusion from the listing.
 EXCLUDE_PATTERN=
 # URL of the Grafana Faro endpoint to send observability data to.
 FARO_ENDPOINT_URL=
+# "true" to force path-style addressing for S3 requests.
+FORCE_PATH_STYLE=

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 AWS_REGION=eu-central-1
 AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+# AWS_ENDPOINT_OVERRIDE=https://my-selfhosted-s3-instance.com
 # Name of the S3 bucket.
 BUCKET_NAME=www.example.com
 # Object key regex pattern for exclusion from the listing.

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 AWS_REGION=eu-central-1
 AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
 AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+# AWS request scheme; e.g. "http" or "https". Defaults to "http".
+AWS_REQUEST_SCHEME=
 # AWS endpoint override; e.g. for local development or self-hosted S3.
 AWS_ENDPOINT_OVERRIDE=
 # Name of the S3 bucket.

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -11,6 +11,7 @@ const envVars = {
   AWS_ACCESS_KEY_ID: undefined,
   AWS_SECRET_ACCESS_KEY: undefined,
   AWS_ENDPOINT_OVERRIDE: null,
+  AWS_REQUEST_SCHEME: null,
   BUCKET_NAME: undefined,
   EXCLUDE_PATTERN: "^index\\.html$",
   FARO_ENDPOINT_URL: null,

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -10,7 +10,7 @@ const envVars = {
   AWS_REGION: undefined,
   AWS_ACCESS_KEY_ID: undefined,
   AWS_SECRET_ACCESS_KEY: undefined,
-  AWS_ENDPOINT: undefined,
+  AWS_ENDPOINT_OVERRIDE: "",
   BUCKET_NAME: undefined,
   EXCLUDE_PATTERN: "^index\\.html$",
   FARO_ENDPOINT_URL: null,

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -10,10 +10,11 @@ const envVars = {
   AWS_REGION: undefined,
   AWS_ACCESS_KEY_ID: undefined,
   AWS_SECRET_ACCESS_KEY: undefined,
-  AWS_ENDPOINT_OVERRIDE: "",
+  AWS_ENDPOINT_OVERRIDE: null,
   BUCKET_NAME: undefined,
   EXCLUDE_PATTERN: "^index\\.html$",
   FARO_ENDPOINT_URL: null,
+  FORCE_PATH_STYLE: null,
 };
 
 // Load variables from .env file into environment.

--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -10,6 +10,7 @@ const envVars = {
   AWS_REGION: undefined,
   AWS_ACCESS_KEY_ID: undefined,
   AWS_SECRET_ACCESS_KEY: undefined,
+  AWS_ENDPOINT: undefined,
   BUCKET_NAME: undefined,
   EXCLUDE_PATTERN: "^index\\.html$",
   FARO_ENDPOINT_URL: null,

--- a/src/hooks/useContents.js
+++ b/src/hooks/useContents.js
@@ -3,11 +3,11 @@ import { S3Client, ListObjectsV2Command } from "@aws-sdk/client-s3";
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,
-  endpoint: process.env.AWS_ENDPOINT_OVERRIDE || undefined,
   credentials: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   },
+  endpoint: process.env.AWS_ENDPOINT_OVERRIDE || undefined,
   forcePathStyle: process.env.FORCE_PATH_STYLE === "true" || undefined,
 });
 

--- a/src/hooks/useContents.js
+++ b/src/hooks/useContents.js
@@ -3,10 +3,12 @@ import { S3Client, ListObjectsV2Command } from "@aws-sdk/client-s3";
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,
+  endpoint: process.env.AWS_ENDPOINT,
   credentials: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   },
+  forcePathStyle: true,
 });
 
 const excludeRegex = new RegExp(process.env.EXCLUDE_PATTERN || /(?!)/);
@@ -37,7 +39,7 @@ const listContents = async (prefix) => {
           lastModified: LastModified,
           size: Size,
           path: Key,
-          url: `http://${process.env.BUCKET_NAME}/${Key}`,
+          url: `${process.env.AWS_ENDPOINT}/${process.env.BUCKET_NAME}/${Key}`,
         })
       ) || [],
   };

--- a/src/hooks/useContents.js
+++ b/src/hooks/useContents.js
@@ -11,15 +11,14 @@ const s3Client = new S3Client({
   forcePathStyle: process.env.FORCE_PATH_STYLE === "true" || undefined,
 });
 
-const urlWithoutScheme = (url) => url.replace(/.*?:\/\//, "");
-
 const getBucketBaseUrl = () => {
   if (!process.env.AWS_ENDPOINT_OVERRIDE) {
-    return `http://${process.env.BUCKET_NAME}`;
+    return `${process.env.AWS_REQUEST_SCHEME}://${process.env.BUCKET_NAME}`;
   }
+  // based on doc at https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
   return process.env.FORCE_PATH_STYLE === "true"
-    ? `http://s3.${process.env.AWS_REGION}.${urlWithoutScheme(process.env.AWS_ENDPOINT_OVERRIDE)}/${process.env.BUCKET_NAME}`
-    : `http://${process.env.BUCKET_NAME}.s3.${process.env.AWS_REGION}.${urlWithoutScheme(process.env.AWS_ENDPOINT_OVERRIDE)}`;
+    ? `${process.env.AWS_REQUEST_SCHEME}://s3.${process.env.AWS_REGION}.${process.env.AWS_ENDPOINT_OVERRIDE}/${process.env.BUCKET_NAME}`
+    : `${process.env.AWS_REQUEST_SCHEME}://${process.env.BUCKET_NAME}.s3.${process.env.AWS_REGION}.${process.env.AWS_ENDPOINT_OVERRIDE}`;
 };
 
 const BUCKET_URL = getBucketBaseUrl();

--- a/src/hooks/useContents.js
+++ b/src/hooks/useContents.js
@@ -8,6 +8,7 @@ const s3Client = new S3Client({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   },
+  forcePathStyle: process.env.FORCE_PATH_STYLE === "true" || undefined,
 });
 
 const BUCKET_URL = !process.env.AWS_ENDPOINT_OVERRIDE

--- a/src/hooks/useContents.js
+++ b/src/hooks/useContents.js
@@ -11,9 +11,16 @@ const s3Client = new S3Client({
   forcePathStyle: process.env.FORCE_PATH_STYLE === "true" || undefined,
 });
 
-const BUCKET_URL = !process.env.AWS_ENDPOINT_OVERRIDE
-  ? `http://${process.env.BUCKET_NAME}`
-  : `${process.env.AWS_ENDPOINT_OVERRIDE}/${process.env.BUCKET_NAME}`;
+const getBucketBaseUrl = () => {
+  if (!process.env.AWS_ENDPOINT_OVERRIDE) {
+    return `http://${process.env.BUCKET_NAME}`;
+  }
+  return process.env.FORCE_PATH_STYLE === "true"
+    ? `http://${process.env.AWS_ENDPOINT_OVERRIDE}/${process.env.BUCKET_NAME}`
+    : `http://${process.env.BUCKET_NAME}.${process.env.AWS_ENDPOINT_OVERRIDE}`;
+};
+
+const BUCKET_URL = getBucketBaseUrl();
 
 const excludeRegex = new RegExp(process.env.EXCLUDE_PATTERN || /(?!)/);
 

--- a/src/hooks/useContents.js
+++ b/src/hooks/useContents.js
@@ -11,13 +11,15 @@ const s3Client = new S3Client({
   forcePathStyle: process.env.FORCE_PATH_STYLE === "true" || undefined,
 });
 
+const urlWithoutScheme = (url) => url.replace(/.*?:\/\//, "");
+
 const getBucketBaseUrl = () => {
   if (!process.env.AWS_ENDPOINT_OVERRIDE) {
     return `http://${process.env.BUCKET_NAME}`;
   }
   return process.env.FORCE_PATH_STYLE === "true"
-    ? `http://s3.${process.env.AWS_REGION}.${process.env.AWS_ENDPOINT_OVERRIDE}/${process.env.BUCKET_NAME}`
-    : `http://${process.env.BUCKET_NAME}.s3.${process.env.AWS_REGION}.${process.env.AWS_ENDPOINT_OVERRIDE}`;
+    ? `http://s3.${process.env.AWS_REGION}.${urlWithoutScheme(process.env.AWS_ENDPOINT_OVERRIDE)}/${process.env.BUCKET_NAME}`
+    : `http://${process.env.BUCKET_NAME}.s3.${process.env.AWS_REGION}.${urlWithoutScheme(process.env.AWS_ENDPOINT_OVERRIDE)}`;
 };
 
 const BUCKET_URL = getBucketBaseUrl();

--- a/src/hooks/useContents.js
+++ b/src/hooks/useContents.js
@@ -3,12 +3,11 @@ import { S3Client, ListObjectsV2Command } from "@aws-sdk/client-s3";
 
 const s3Client = new S3Client({
   region: process.env.AWS_REGION,
-  endpoint: process.env.AWS_ENDPOINT,
+  endpoint: process.env.AWS_ENDPOINT_OVERRIDE || undefined,
   credentials: {
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
   },
-  forcePathStyle: true,
 });
 
 const excludeRegex = new RegExp(process.env.EXCLUDE_PATTERN || /(?!)/);
@@ -39,7 +38,10 @@ const listContents = async (prefix) => {
           lastModified: LastModified,
           size: Size,
           path: Key,
-          url: `${process.env.AWS_ENDPOINT}/${process.env.BUCKET_NAME}/${Key}`,
+          url:
+            process.env.AWS_ENDPOINT_OVERRIDE === ""
+              ? `http://${process.env.BUCKET_NAME}/${Key}`
+              : `${process.env.AWS_ENDPOINT_OVERRIDE}/${process.env.BUCKET_NAME}/${Key}`,
         })
       ) || [],
   };

--- a/src/hooks/useContents.js
+++ b/src/hooks/useContents.js
@@ -10,6 +10,10 @@ const s3Client = new S3Client({
   },
 });
 
+const BUCKET_URL = !process.env.AWS_ENDPOINT_OVERRIDE
+  ? `http://${process.env.BUCKET_NAME}`
+  : `${process.env.AWS_ENDPOINT_OVERRIDE}/${process.env.BUCKET_NAME}`;
+
 const excludeRegex = new RegExp(process.env.EXCLUDE_PATTERN || /(?!)/);
 
 const listContents = async (prefix) => {
@@ -38,10 +42,7 @@ const listContents = async (prefix) => {
           lastModified: LastModified,
           size: Size,
           path: Key,
-          url:
-            process.env.AWS_ENDPOINT_OVERRIDE === ""
-              ? `http://${process.env.BUCKET_NAME}/${Key}`
-              : `${process.env.AWS_ENDPOINT_OVERRIDE}/${process.env.BUCKET_NAME}/${Key}`,
+          url: `${BUCKET_URL}/${Key}`,
         })
       ) || [],
   };

--- a/src/hooks/useContents.js
+++ b/src/hooks/useContents.js
@@ -16,8 +16,8 @@ const getBucketBaseUrl = () => {
     return `http://${process.env.BUCKET_NAME}`;
   }
   return process.env.FORCE_PATH_STYLE === "true"
-    ? `http://${process.env.AWS_ENDPOINT_OVERRIDE}/${process.env.BUCKET_NAME}`
-    : `http://${process.env.BUCKET_NAME}.${process.env.AWS_ENDPOINT_OVERRIDE}`;
+    ? `http://s3.${process.env.AWS_REGION}.${process.env.AWS_ENDPOINT_OVERRIDE}/${process.env.BUCKET_NAME}`
+    : `http://${process.env.BUCKET_NAME}.s3.${process.env.AWS_REGION}.${process.env.AWS_ENDPOINT_OVERRIDE}`;
 };
 
 const BUCKET_URL = getBucketBaseUrl();


### PR DESCRIPTION
Hello, thank you for your work!

Your project has been useful to me for presenting data to non-technical users, using a local development [LocalStack](https://www.localstack.cloud/) server as an S3 instance.

To achieve this goal, I tinkered a bit with your tool in local.

I figured out it could be useful to other people, so I made the tinkering a real thing by cleaning up my changes and opening this pull request.

# Feature

- Allow users to use your application with self-hosted or local S3 instances, by allowing endpoint overriding
  - Add an `AWS_ENDPOINT_OVERRIDE` environment variable for overriding endpoint
  - Add an `AWS_REQUEST_SCHEME` environment variable for allowing to choose between `http` and `https`
- Add support for path-style URLs (old URLs)
  - Add a `FORCE_PATH_STYLE` environment variable for enforcing usage of old path-style URLs instead of virtual-hosted-style URLs